### PR TITLE
Gradle plugin: Fix duplicated jars in the classpath

### DIFF
--- a/cabe-gradle-plugin/src/main/java/com/dua3/cabe/gradle/CabeTask.java
+++ b/cabe-gradle-plugin/src/main/java/com/dua3/cabe/gradle/CabeTask.java
@@ -138,6 +138,7 @@ public abstract class CabeTask extends DefaultTask {
                             getRuntimeClassPath().get().getFiles().stream()
                     )
                     .map(File::toString)
+                    .distinct()
                     .collect(Collectors.joining(File.pathSeparator));
 
             String javaExec = javaExecutable.get();


### PR DESCRIPTION
I noticed that when the compile classpath and the runtime classpath overlap, then the jars appear in `-cp` twice.

A log fragment when running `build` for `/examples/hello` (I set verbosity to `2`):
```
FINE: args: -i /home/mk/projects/java/cabe2/examples/hello/build/classes-cabe-input -o /home/mk/projects/java/cabe2/examples/hello/build/classes/java/main -c publicApi=THROW_NPE:privateApi=ASSERT:returnValue=NO_CHECK -cp /home/mk/.m2/repository/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar:/home/mk/.m2/repository/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar -v 2
```

After the change in this PR, the output looks as follows:
```
FINE: args: -i /home/mk/projects/java/cabe2/examples/hello/build/classes-cabe-input -o /home/mk/projects/java/cabe2/examples/hello/build/classes/java/main -c publicApi=THROW_NPE:privateApi=ASSERT:returnValue=NO_CHECK -cp /home/mk/.m2/repository/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar -v 2
```